### PR TITLE
improve performance of dtw

### DIFF
--- a/rhasspywake_raven/dtw.py
+++ b/rhasspywake_raven/dtw.py
@@ -42,33 +42,24 @@ class DynamicTimeWarping:
         row = m - 1
         col = n - 1
         path = [(row, col)]
-        eps = 1e-14
 
-        while (row > 0) or (col > 0):
-            if (row > 0) and (col > 0):
-                min_cost = min(
-                    self.cost_matrix[row - 1][col],  # insertion
-                    self.cost_matrix[row][col - 1],  # deletion
-                    self.cost_matrix[row - 1][col - 1],  # match
-                )
-
-                if math.isclose(
-                    min_cost, self.cost_matrix[row - 1][col - 1], rel_tol=eps
-                ):
-                    row = row - 1
-                    col = col - 1
-                elif math.isclose(
-                    min_cost, self.cost_matrix[row - 1][col], rel_tol=eps
-                ):
-                    row = row - 1
-                elif math.isclose(
-                    min_cost, self.cost_matrix[row][col - 1], rel_tol=eps
-                ):
-                    col = col - 1
-            elif (row > 0) and (col == 0):
-                row = row - 1
-            elif (row == 0) and (col > 0):
-                col = col - 1
+        while row or col:
+            if row and col:
+                insertion = self.cost_matrix[row - 1, col]
+                deletion = self.cost_matrix[row, col - 1]
+                match = self.cost_matrix[row - 1, col - 1]
+ 
+                if match <= insertion and match <= deletion:
+                    row -= 1
+                    col -= 1
+                elif insertion <= deletion:
+                    row -= 1
+                else:
+                    col -= 1
+            elif row:
+                row -= 1
+            elif col:
+                col -= 1
 
             path.append((row, col))
 
@@ -90,32 +81,26 @@ class DynamicTimeWarping:
         if len(y.shape) == 1:
             y = y.reshape(-1, 1)
 
-        distance_matrix = scipy.spatial.distance.cdist(x, y, metric=self.distance_func)
-
-        cost_matrix = np.full(shape=(m, n), fill_value=math.inf, dtype=float)
-        cost_matrix[0][0] = distance_matrix[0][0]
+        cost_matrix = scipy.spatial.distance.cdist(x, y, metric=self.distance_func)
 
         for row in range(1, m):
-            cost = distance_matrix[row, 0]
-            cost_matrix[row][0] = cost + cost_matrix[row - 1][0]
+            cost_matrix[row, 0] += cost_matrix[row - 1, 0]
 
         for col in range(1, n):
-            cost = distance_matrix[0, col]
-            cost_matrix[0][col] = cost + cost_matrix[0][col - 1]
+            cost_matrix[0, col] += cost_matrix[0, col - 1]
 
         for row in range(1, m):
             for col in range(1, n):
-                cost = distance_matrix[row, col]
-                cost_matrix[row][col] = cost + min(
-                    cost_matrix[row - 1][col],  # insertion
-                    cost_matrix[row][col - 1],  # deletion
-                    cost_matrix[row - 1][col - 1],  # match
+                cost_matrix[row, col] += min(
+                    cost_matrix[row - 1, col],  # insertion
+                    cost_matrix[row, col - 1],  # deletion
+                    cost_matrix[row - 1, col - 1],  # match
                 )
 
         if keep_matrix:
             self.cost_matrix = cost_matrix
 
-        distance = cost_matrix[m - 1][n - 1]
+        distance = cost_matrix[m - 1, n - 1]
         self.distance = distance
 
         return distance
@@ -147,7 +132,7 @@ class DynamicTimeWarping:
 
         cost_matrix = np.full(shape=(n + 1, m + 1), fill_value=math.inf, dtype=float)
 
-        cost_matrix[0][0] = 0
+        cost_matrix[0, 0] = 0
         for row in range(1, n + 1):
             col_start = max(1, row - window)
             col_end = min(m, row + window)
@@ -156,10 +141,10 @@ class DynamicTimeWarping:
                 cost = distance_matrix[row - 1, col - 1]
 
                 # symmetric step pattern
-                cost_matrix[row][col] = min(
-                    (step_pattern * cost) + cost_matrix[row - 1][col - 1],
-                    cost + cost_matrix[row - 1][col],
-                    cost + cost_matrix[row][col - 1],
+                cost_matrix[row, col] = min(
+                    (step_pattern * cost) + cost_matrix[row - 1, col - 1],
+                    cost + cost_matrix[row - 1, col],
+                    cost + cost_matrix[row, col - 1],
                 )
 
         if keep_matrix:


### PR DESCRIPTION
These changes add some performance improvements to the dtw calculation. The main reason for the changes is the preparation for the transition to [Cython](https://github.com/cython/cython). This way the actual transition requires less changes (e.g. the matrix access [a,b] can be optimized into direct accesses to the underlying matrix by Cython, which does not work when using the syntax [a][b])

@synesthesiam could you take a quick look at this?