### PR TITLE
Fixed scipy egg version unsupported in Python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python_speech_features==0.6
-scipy==1.6.0
+scipy>=1.7.0
 rhasspy-silence~=0.4.0


### PR DESCRIPTION
Due to [cythonizing bugs](https://github.com/scipy/scipy/issues/14826), SciPy 1.6 does not support Python 3.10, which prevents the program from being run on Mint Linux equipped with Python 3.10. This PR fixes it, increasing the version to 1.7 or even 1.8.1 is tested as safe.